### PR TITLE
[Epic 2] Implement Character Data - Issue #5

### DIFF
--- a/src/data/characters.ts
+++ b/src/data/characters.ts
@@ -1,0 +1,89 @@
+// ABOUTME: Character data for all main Final Fantasy VIII characters
+// ABOUTME: Exports typed array of Character objects for use in components
+
+import type { Character } from './types';
+
+/**
+ * Array of all main playable characters in Final Fantasy VIII
+ *
+ * Contains complete character data for:
+ * - Squall Leonhart (Main Protagonist)
+ * - Rinoa Heartilly (Resistance Fighter)
+ * - Quistis Trepe (Instructor)
+ * - Zell Dincht (Martial Artist)
+ * - Selphie Tilmitt (Messenger)
+ * - Irvine Kinneas (Sharpshooter)
+ *
+ * Each character includes biographical information, combat stats,
+ * and memorable quotes where applicable.
+ */
+export const characters: Character[] = [
+  {
+    id: 'squall',
+    name: 'Squall Leonhart',
+    role: 'Main Protagonist',
+    age: 17,
+    description:
+      'A lone wolf and leader of SeeD, Squall wields a gunblade and struggles with opening up to others. As the commander of Balamb Garden, he must learn to trust his companions and confront his past.',
+    imageUrl: '/images/characters/squall.webp',
+    weapon: 'Gunblade (Revolver)',
+    limitBreak: 'Renzokuken',
+    quote: 'Whatever...',
+  },
+  {
+    id: 'rinoa',
+    name: 'Rinoa Heartilly',
+    role: 'Resistance Fighter',
+    age: 17,
+    description:
+      "A passionate member of the Forest Owls resistance group who brings warmth to Squall's cold exterior. Her determination and compassion help bridge the gap between duty and emotion.",
+    imageUrl: '/images/characters/rinoa.webp',
+    weapon: 'Blaster Edge',
+    limitBreak: 'Angel Wing',
+    quote: "I'll be waiting for you.",
+  },
+  {
+    id: 'quistis',
+    name: 'Quistis Trepe',
+    role: 'Instructor',
+    age: 18,
+    description:
+      'A talented young instructor at Balamb Garden who uses Blue Magic and a whip in combat. Despite her youth, she commands respect through her intelligence and combat prowess.',
+    imageUrl: '/images/characters/quistis.webp',
+    weapon: 'Save the Queen (Whip)',
+    limitBreak: 'Blue Magic',
+  },
+  {
+    id: 'zell',
+    name: 'Zell Dincht',
+    role: 'Martial Artist',
+    age: 17,
+    description:
+      'An energetic martial artist with a love for hot dogs and a fierce fighting spirit. His enthusiasm and loyalty make him an invaluable member of the team.',
+    imageUrl: '/images/characters/zell.webp',
+    weapon: 'Gauntlets',
+    limitBreak: 'Duel',
+  },
+  {
+    id: 'selphie',
+    name: 'Selphie Tilmitt',
+    role: 'Messenger',
+    age: 17,
+    description:
+      'A cheerful and optimistic SeeD member from Trabia Garden who wields nunchaku. Her upbeat personality and hidden depths surprise those who underestimate her.',
+    imageUrl: '/images/characters/selphie.webp',
+    weapon: 'Nunchaku',
+    limitBreak: 'Slot',
+  },
+  {
+    id: 'irvine',
+    name: 'Irvine Kinneas',
+    role: 'Sharpshooter',
+    age: 17,
+    description:
+      'A smooth-talking sniper from Galbadia Garden with a mysterious past. Behind his confident facade lies a sensitive soul burdened by memories.',
+    imageUrl: '/images/characters/irvine.webp',
+    weapon: 'Rifle',
+    limitBreak: 'Shot',
+  },
+];


### PR DESCRIPTION
## Issue #5: Implement Character Data

This PR implements character data for all 6 main Final Fantasy VIII characters.

### Changes Made

- ✅ Created `src/data/characters.ts` with typed character array
- ✅ Added complete data for all 6 main characters:
  - **Squall Leonhart** - Main Protagonist, age 17, Gunblade, Renzokuken
  - **Rinoa Heartilly** - Resistance Fighter, age 17, Blaster Edge, Angel Wing
  - **Quistis Trepe** - Instructor, age 18, Whip, Blue Magic
  - **Zell Dincht** - Martial Artist, age 17, Gauntlets, Duel
  - **Selphie Tilmitt** - Messenger, age 17, Nunchaku, Slot
  - **Irvine Kinneas** - Sharpshooter, age 17, Rifle, Shot
- ✅ All required fields populated (id, name, role, age, description, imageUrl, weapon, limitBreak)
- ✅ Added memorable quotes for Squall and Rinoa
- ✅ Added comprehensive JSDoc documentation
- ✅ Added ABOUTME header comments
- ✅ Ensured TypeScript strict mode compliance

### Verification

- ✅ TypeScript compilation passes (`tsc --noEmit`)
- ✅ ESLint passes with no errors
- ✅ Prettier formatting applied
- ✅ Production build succeeds (1.78s)
- ✅ All acceptance criteria met (AC2.2)

### Acceptance Criteria

- ✅ AC2.2: Exactly 6 characters are defined
- ✅ All characters have complete data (name, role, age, description, weapon, limitBreak)
- ✅ Data validates against Character interface from `src/data/types.ts`

### Reference

- Backend Architecture: `.claude/doc/ff8-landing-page-initial-setup/backend.md`
- Acceptance Criteria: `.claude/doc/ff8-landing-page-initial-setup/acceptance_criteria.md` (AC2.2)
- Issue: #5

### Dependencies

- ✅ Issue #4: Define TypeScript Interfaces (merged to master)

### Next Steps

- Await QA validation from @acceptance-validator and @security-architect
- Merge to master after approval
- Proceed with Issue #6: Implement Game Details Data

Resolves #5